### PR TITLE
Fix Function Conditional step in kinesisEngine.prototype.step

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ KinesisEngine.prototype.step = function step (rs, ee) {
 
   if (rs.function) {
     return function (context, callback) {
-      let func = self.config.processor[rs.function];
+      let func = self.script.config.processor[rs.function];
       if (!func) {
         return process.nextTick(function () { callback(null, context); });
       }


### PR DESCRIPTION
Function conditional in kinesisEngine.prototype.step was not referencing the actual script which was causing processors to fail if a function was included in a flow. 

Updated conditional to reference self.script... instead of self...


